### PR TITLE
Fix Vite permission error for Vercel builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "npx vite build",
-    "preview": "vite preview"
+    "dev": "node node_modules/vite/bin/vite.js",
+    "build": "node node_modules/vite/bin/vite.js build",
+    "preview": "node node_modules/vite/bin/vite.js preview",
+    "postinstall": "chmod +x node_modules/.bin/vite"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.5.1",

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "npx vite build",
+  "buildCommand": "node node_modules/vite/bin/vite.js build",
   "outputDirectory": "dist",
   "installCommand": "npm install",
   "ignoreCommand": "echo 'ignore'"


### PR DESCRIPTION
## Summary
- execute Vite using Node so the binary doesn't need execute permissions
- adjust Vercel build command accordingly

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_685a410a5a94832cbd0a9d5ac85aa37e